### PR TITLE
Fixed error in create_time option.

### DIFF
--- a/OpenTok.cs
+++ b/OpenTok.cs
@@ -51,7 +51,7 @@ namespace OpenTok
             NameValueCollection appSettings = ConfigurationManager.AppSettings;
 
             options.Add("session_id", sessionId);
-            options.Add("create_time", Convert.ToInt32(DateTime.Now.ToUniversalTime().Ticks - 621355968000000000) / 10000000));
+            options.Add("create_time", (int)(DateTime.UtcNow - new DateTime(1970, 1, 1)).TotalSeconds);            
             options.Add("nonce", RandomNumber(0, 999999));
             if (!options.ContainsKey(TokenPropertyConstants.ROLE))
             {


### PR DESCRIPTION
The number from the calculation exceeded Int32.  

If the conversion was removed, the API complained that the date 
was in the future.

I looked at the PHP API and found that it was using the time() function.  I then changed the code to a C# equivalent.
