### PR TITLE
Update REST API URL from /partner to /project

### DIFF
--- a/OpenTok/OpenTok.cs
+++ b/OpenTok/OpenTok.cs
@@ -249,7 +249,7 @@ namespace OpenTokSDK
             {
                 throw new OpenTokArgumentException("Session not valid");
             }
-            string url = string.Format("v2/partner/{0}/archive", this.ApiKey);
+            string url = string.Format("v2/project/{0}/archive", this.ApiKey);
             var headers = new Dictionary<string, string> { { "Content-type", "application/json" } };
             var data = new Dictionary<string, object>() { { "sessionId", sessionId }, { "name", name }, { "hasVideo", hasVideo }, { "hasAudio", hasAudio }, { "outputMode", outputMode.ToString().ToLower() } };
             string response = Client.Post(url, headers, data);
@@ -267,7 +267,7 @@ namespace OpenTokSDK
          */
         public Archive StopArchive(string archiveId)
         {
-            string url = string.Format("v2/partner/{0}/archive/{1}/stop", this.ApiKey, archiveId);
+            string url = string.Format("v2/project/{0}/archive/{1}/stop", this.ApiKey, archiveId);
             var headers = new Dictionary<string, string> { { "Content-type", "application/json" } };
 
             string response = Client.Post(url, headers, new Dictionary<string, object>());
@@ -306,7 +306,7 @@ namespace OpenTokSDK
             {
                 throw new OpenTokArgumentException("count cannot be smaller than 1");
             }
-            string url = string.Format("v2/partner/{0}/archive?offset={1}", this.ApiKey, offset);
+            string url = string.Format("v2/project/{0}/archive?offset={1}", this.ApiKey, offset);
             if (count > 0)
             {
                 url = string.Format("{0}&count={1}", url, count);
@@ -326,7 +326,7 @@ namespace OpenTokSDK
          */
         public Archive GetArchive(string archiveId)
         {
-            string url = string.Format("v2/partner/{0}/archive/{1}", this.ApiKey, archiveId);
+            string url = string.Format("v2/project/{0}/archive/{1}", this.ApiKey, archiveId);
             var headers = new Dictionary<string, string> { { "Content-type", "application/json" } };
             string response = Client.Get(url); ;
             return JsonConvert.DeserializeObject<Archive>(response);
@@ -343,7 +343,7 @@ namespace OpenTokSDK
          */
         public void DeleteArchive(string archiveId)
         {
-            string url = string.Format("v2/partner/{0}/archive/{1}", this.ApiKey, archiveId);
+            string url = string.Format("v2/project/{0}/archive/{1}", this.ApiKey, archiveId);
             var headers = new Dictionary<string, string> { { "Content-type", "application/json" } };
             Client.Delete(url, headers, new Dictionary<string, object>());
         }

--- a/OpenTokTest/OpenTokTest.cs
+++ b/OpenTokTest/OpenTokTest.cs
@@ -358,7 +358,7 @@ namespace OpenTokSDKTest
             Assert.Equal("http://tokbox.com.archive2.s3.amazonaws.com/123456%2F" + archiveId + "%2Farchive.mp4?Expires=13951" +
                     "94362&AWSAccessKeyId=AKIAI6LQCPIXYVWCQV6Q&Signature=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", archive.Url);
 
-            mockClient.Verify(httpClient => httpClient.Get(It.Is<string>(url => url.Equals("v2/partner/"+this.apiKey+"/archive/"+archiveId))), Times.Once());
+            mockClient.Verify(httpClient => httpClient.Get(It.Is<string>(url => url.Equals("v2/project/"+this.apiKey+"/archive/"+archiveId))), Times.Once());
         }
 
         [Fact]
@@ -386,7 +386,7 @@ namespace OpenTokSDKTest
             Assert.NotNull(archive);
             Assert.Equal(ArchiveStatus.EXPIRED, archive.Status);
 
-            mockClient.Verify(httpClient => httpClient.Get(It.Is<string>(url => url.Equals("v2/partner/" + this.apiKey + "/archive/" + archiveId))), Times.Once());
+            mockClient.Verify(httpClient => httpClient.Get(It.Is<string>(url => url.Equals("v2/project/" + this.apiKey + "/archive/" + archiveId))), Times.Once());
         }
 
         public void GetArchiveWithUnknownPropertiesTest()
@@ -413,7 +413,7 @@ namespace OpenTokSDKTest
 
             Assert.NotNull(archive);
 
-            mockClient.Verify(httpClient => httpClient.Get(It.Is<string>(url => url.Equals("v2/partner/" + this.apiKey + "/archive/" + archiveId))), Times.Once());
+            mockClient.Verify(httpClient => httpClient.Get(It.Is<string>(url => url.Equals("v2/project/" + this.apiKey + "/archive/" + archiveId))), Times.Once());
         }
 
         
@@ -512,7 +512,7 @@ namespace OpenTokSDKTest
             Assert.NotNull(archives);
             Assert.Equal(6, archives.Count);
 
-            mockClient.Verify(httpClient => httpClient.Get(It.Is<string>(url => url.Equals("v2/partner/"+apiKey + "/archive?offset=0"))), Times.Once());
+            mockClient.Verify(httpClient => httpClient.Get(It.Is<string>(url => url.Equals("v2/project/"+apiKey + "/archive?offset=0"))), Times.Once());
         }
 
         [Fact]
@@ -542,7 +542,7 @@ namespace OpenTokSDKTest
             Assert.Equal(sessionId, archive.SessionId);
             Assert.NotNull(archive.Id);
 
-            mockClient.Verify(httpClient => httpClient.Post(It.Is<string>(url => url.Equals("v2/partner/"+ apiKey +"/archive")), It.IsAny<Dictionary<string, string>>(), It.IsAny<Dictionary<string, object>>()), Times.Once());
+            mockClient.Verify(httpClient => httpClient.Post(It.Is<string>(url => url.Equals("v2/project/"+ apiKey +"/archive")), It.IsAny<Dictionary<string, string>>(), It.IsAny<Dictionary<string, object>>()), Times.Once());
         }
 
         [Fact]
@@ -572,7 +572,7 @@ namespace OpenTokSDKTest
             Assert.NotNull(archive);
             Assert.Equal(OutputMode.INDIVIDUAL, archive.OutputMode);
 
-            mockClient.Verify(httpClient => httpClient.Post(It.Is<string>(url => url.Equals("v2/partner/" + apiKey + "/archive")), It.IsAny<Dictionary<string, string>>(), It.IsAny<Dictionary<string, object>>()), Times.Once());
+            mockClient.Verify(httpClient => httpClient.Post(It.Is<string>(url => url.Equals("v2/project/" + apiKey + "/archive")), It.IsAny<Dictionary<string, string>>(), It.IsAny<Dictionary<string, object>>()), Times.Once());
         }
 
         [Fact]
@@ -604,7 +604,7 @@ namespace OpenTokSDKTest
             Assert.Equal(sessionId, archive.SessionId);
             Assert.NotNull(archive.Id);
 
-            mockClient.Verify(httpClient => httpClient.Post(It.Is<string>(url => url.Equals("v2/partner/" + apiKey + "/archive")), It.IsAny<Dictionary<string, string>>(), It.IsAny<Dictionary<string, object>>()), Times.Once());
+            mockClient.Verify(httpClient => httpClient.Post(It.Is<string>(url => url.Equals("v2/project/" + apiKey + "/archive")), It.IsAny<Dictionary<string, string>>(), It.IsAny<Dictionary<string, object>>()), Times.Once());
         }
 
         [Fact]
@@ -637,7 +637,7 @@ namespace OpenTokSDKTest
             Assert.Equal(archiveId, archive.Id.ToString());
 
             mockClient.Verify(httpClient => httpClient.Post(It.Is<string>(
-                url => url.Equals("v2/partner/" + apiKey + "/archive/" + archiveId +"/stop")), 
+                url => url.Equals("v2/project/" + apiKey + "/archive/" + archiveId +"/stop")), 
                 It.IsAny<Dictionary<string, string>>(), 
                 It.IsAny<Dictionary<string, object>>()), Times.Once());
         }
@@ -657,7 +657,7 @@ namespace OpenTokSDKTest
             opentok.DeleteArchive(archiveId);
 
             mockClient.Verify(httpClient => httpClient.Delete(It.Is<string>(
-                url => url.Equals("v2/partner/" + apiKey + "/archive/" + archiveId)),
+                url => url.Equals("v2/project/" + apiKey + "/archive/" + archiveId)),
                 It.IsAny<Dictionary<string, string>>(),
                 It.IsAny<Dictionary<string, object>>()), Times.Once());
         }


### PR DESCRIPTION
/partner is deprecated and will no longer by supported from July 2017