### PR TITLE
Bump version to 2.4.1

### DIFF
--- a/OpenTok/Properties/AssemblyInfo.cs
+++ b/OpenTok/Properties/AssemblyInfo.cs
@@ -33,4 +33,4 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("2.4.*")]
-[assembly: AssemblyInformationalVersion("2.4.0")]
+[assembly: AssemblyInformationalVersion("2.4.1")]


### PR DESCRIPTION
- Nuget failed when publishing 2.4.0 and now I can't reuse the same version number.