### PR TITLE
updates for nuget package - adding 4.6.1

### DIFF
--- a/OpenTok/OpenTok.csproj
+++ b/OpenTok/OpenTok.csproj
@@ -1,10 +1,28 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;net46;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net452;net46;net461;netstandard2.0</TargetFrameworks>
+    <Version>3.2.0</Version>
+    <Description>OpenTok is an API from TokBox that enables websites to weave live group video communication into their online experience.</Description>
+    <PackageProjectUrl>https://github.com/opentok/Opentok-.NET-SDK</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/opentok/Opentok-.NET-SDK</RepositoryUrl>
+    <PackageReleaseNotes>https://github.com/opentok/Opentok-.NET-SDK/releases/tag/v3.2.0</PackageReleaseNotes>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <ProjectGuid>{C770C266-B8E6-413A-B5AB-68EB218DC76C}</ProjectGuid>
+    <NuGetPackageImportStamp>671ed443</NuGetPackageImportStamp>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net452|AnyCPU'">
+    <DocumentationFile></DocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452'">
+    <PackageReference Include="JWT" Version="2.3.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' ==  'net46'">
     <PackageReference Include="JWT" Version="2.3.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
@@ -12,7 +30,12 @@
     <PackageReference Include="JWT" Version="7.2.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461'">
+    <PackageReference Include="JWT" Version="7.2.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+  </ItemGroup>
+  
+  <ItemGroup>    
     <Reference Include="System.Web" />
   </ItemGroup>
 


### PR DESCRIPTION
Adding a 4.6.1 package path as well as .NET framework will supersede .NET Standard on dependency path. Also added a bunch of stuff to the csproj file to accommodate nuget packaging 