### PR TITLE
Quality of Life Updates for bad TLS versions

### DIFF
--- a/OpenTok/Util/HttpClient.cs
+++ b/OpenTok/Util/HttpClient.cs
@@ -123,7 +123,7 @@ namespace OpenTokSDK.Util
             }
             catch (WebException e)
             {
-                DebugLog("WebException Status: " + e.Status + ", Message: " + e.Message);                
+                DebugLog("WebException Status: " + e.Status + ", Message: " + e.Message);
 
                 response = (HttpWebResponse)e.Response;
 

--- a/OpenTok/Util/HttpClient.cs
+++ b/OpenTok/Util/HttpClient.cs
@@ -123,7 +123,7 @@ namespace OpenTokSDK.Util
             }
             catch (WebException e)
             {
-                DebugLog("WebException Status: " + e.Status + ", Message: " + e.Message);
+                DebugLog("WebException Status: " + e.Status + ", Message: " + e.Message);                
 
                 response = (HttpWebResponse)e.Response;
 
@@ -141,6 +141,8 @@ namespace OpenTokSDK.Util
                         }
                     }
                 }
+
+                OpenTokUtils.ValidateTlsVersion(e);
 
                 throw new OpenTokWebException("Error with request submission", e);
             }

--- a/OpenTok/Util/OpenTokUtils.cs
+++ b/OpenTok/Util/OpenTokUtils.cs
@@ -7,6 +7,7 @@ using System.Security.Cryptography;
 using System.Net;
 
 using Newtonsoft.Json;
+using OpenTokSDK.Exception;
 
 namespace OpenTokSDK.Util
 {
@@ -157,6 +158,22 @@ namespace OpenTokSDK.Util
             }
 
             return Convert.ToInt32(sessionParameters[1]);
+        }
+
+        /// <summary>
+        /// Used if a WebException is caught to check that the TLS version makes sense
+        /// If the TLS version is less than 1.2 and not the System Default (0) this method
+        /// throws an exception
+        /// </summary>
+        /// <param name="e"></param>
+        public static void ValidateTlsVersion(WebException e)
+        {
+            if (ServicePointManager.SecurityProtocol > 0 && ServicePointManager.SecurityProtocol < SecurityProtocolType.Tls12)
+            {
+                throw new OpenTokWebException("Error with request submission.\n" +
+                    "This application appears to not support TLS1.2.\n" +
+                    "Please enable TLS 1.2 and try again.", e);
+            }
         }
     }
 }

--- a/OpenTokTest/OpenTokTest.cs
+++ b/OpenTokTest/OpenTokTest.cs
@@ -10,6 +10,7 @@ using Moq;
 using OpenTokSDK;
 using OpenTokSDK.Util;
 using OpenTokSDK.Exception;
+using System.Net;
 
 namespace OpenTokSDKTest
 {
@@ -23,6 +24,28 @@ namespace OpenTokSDKTest
         {
             var opentok = new OpenTok(apiKey, apiSecret);
             Assert.IsType(typeof(OpenTok), opentok);
+        }
+
+        [Theory]
+        [InlineData(SecurityProtocolType.Tls11)]
+        [InlineData(SecurityProtocolType.Tls12)]
+        [InlineData((SecurityProtocolType)0)]
+        public void CreateSessionFailedDueToTLS(SecurityProtocolType protocolType)
+        {            
+            ServicePointManager.SecurityProtocol = protocolType;
+            var e = new WebException("Test Exception");
+            try
+            {
+                OpenTokUtils.ValidateTlsVersion(e);                
+                Assert.NotEqual(SecurityProtocolType.Tls11, protocolType);
+            }
+            catch(OpenTokWebException ex)
+            {
+                Assert.Equal("Error with request submission.\nThis application appears to not support TLS1.2.\nPlease enable TLS 1.2 and try again.", ex.Message);
+                Assert.Equal(SecurityProtocolType.Tls11, protocolType);
+
+            }
+            
         }
         
         // TODO: all create session and archive tests should verify the HTTP request body

--- a/README.md
+++ b/README.md
@@ -262,6 +262,12 @@ The OpenTok .NET SDK requires .NET Framework 4.5.2 or greater.
 ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 ```
 
+Alternatively, if your application is dependant on a different version of TLS for other APIs, you can alternatively add TLS to the list of supported methods with a bitwise OR:
+
+```
+ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
+```
+
 ## Release Notes
 
 See the [Releases](https://github.com/opentok/opentok-.net-sdk/releases) page for details


### PR DESCRIPTION
As it stands now if someone uses a bad version of TLS the .NET SDK will fail with a generic error (previously it was a Null reference exception but that was fixed). This PR makes the error more explicit the developers seeing it. I've also changed the way the suggested patch is worded for TLS 1.2 support to inform folks that there is a way to set the TLS version via bitwise OR, which will not disable their other TLS versions (in case their app is consuming a other APIs that don't support TLS 1.2). Addresses #108 