### PR TITLE
list archive by session id, better Session Id Validation

### DIFF
--- a/OpenTok/OpenTok.cs
+++ b/OpenTok/OpenTok.cs
@@ -317,7 +317,7 @@ namespace OpenTokSDK
          * @throws OpenTokArgumentException if count less than 0 or SessionId is set and is invalidly formatted
          *
          * @return A List of Archive objects.
-         */        
+         */
         public ArchiveList ListArchives(int offset = 0 , int count = 0, string sessionId = "")
         {
             if (count < 0)

--- a/OpenTok/OpenTok.cs
+++ b/OpenTok/OpenTok.cs
@@ -298,20 +298,7 @@ namespace OpenTokSDK
 
             string response = Client.Post(url, headers, new Dictionary<string, object>());
             return JsonConvert.DeserializeObject<Archive>(response);
-        }
-
-        /**
-         * Returns a List of Archive objects, representing archives that are both
-         * both completed and in-progress, for your API key. This list is limited to 1000 archives
-         * starting with the first archive recorded. For a specific range of archives, call
-         * listArchives(int offset, int count).
-         *
-         * @return A List of Archive objects.
-         */
-        public ArchiveList ListArchives()
-        {
-            return ListArchives(0, 0);
-        }
+        }        
 
         /**
          * Returns a List of Archive objects, representing archives that are both
@@ -319,23 +306,36 @@ namespace OpenTokSDK
          *
          * @param offset The index offset of the first archive. 0 is offset of the most recently
          * started archive. 1 is the offset of the archive that started prior to the most recent
-         * archive.
+         * archive. Defaults to 0
          *
          * @param count The number of archives to be returned. The maximum number of archives
-         * returned is 1000.
+         * returned is 1000. Defaults to 0, which means the count will not be set
+         *
+         * @param sessionId The id of the session that you would like to search for. Defaults to empty
+         * if sessionId is set it must be validly formatted
+         * 
+         * @throws OpenTokArgumentException if count less than 0 or SessionId is set and is invalidly formatted
          *
          * @return A List of Archive objects.
-         */
-        public ArchiveList ListArchives(int offset, int count)
+         */        
+        public ArchiveList ListArchives(int offset = 0 , int count = 0, string sessionId = "")
         {
             if (count < 0)
             {
-                throw new OpenTokArgumentException("count cannot be smaller than 1");
+                throw new OpenTokArgumentException("count cannot be smaller than 0");
             }
             string url = string.Format("v2/project/{0}/archive?offset={1}", this.ApiKey, offset);
             if (count > 0)
             {
                 url = string.Format("{0}&count={1}", url, count);
+            }
+            if (!string.IsNullOrEmpty(sessionId))
+            {
+                if (!OpenTokUtils.ValidateSession(sessionId))
+                {
+                    throw new OpenTokArgumentException("Session Id is not valid");
+                }
+                url = $"{url}&sessionId={sessionId}";
             }
             string response = Client.Get(url);
             JObject archives = JObject.Parse(response);

--- a/OpenTok/Util/OpenTokUtils.cs
+++ b/OpenTok/Util/OpenTokUtils.cs
@@ -156,6 +156,11 @@ namespace OpenTokSDK.Util
                 throw new FormatException("Session id could not be decoded");
             }
 
+            if (sessionParameters.Count() < 2)
+            {
+                throw new FormatException("Session id could not be decoded");
+            }
+
             return Convert.ToInt32(sessionParameters[1]);
         }
     }

--- a/OpenTokTest/OpenTokTest.cs
+++ b/OpenTokTest/OpenTokTest.cs
@@ -1488,7 +1488,7 @@ namespace OpenTokSDKTest
             opentok.SetStreamClassLists(sessionId, streamPropertiesList);
             
             mockClient.Verify(httpClient => httpClient.Put(It.Is<string>(url => url.Equals("v2/project/" + apiKey + "/session/" + sessionId + "/stream")), It.IsAny<Dictionary<string, string>>(), It.IsAny<Dictionary<string, object>>()), Times.Once());
-        }        
+        }
     }
 }
 

--- a/OpenTokTest/OpenTokTest.cs
+++ b/OpenTokTest/OpenTokTest.cs
@@ -1488,9 +1488,7 @@ namespace OpenTokSDKTest
             opentok.SetStreamClassLists(sessionId, streamPropertiesList);
             
             mockClient.Verify(httpClient => httpClient.Put(It.Is<string>(url => url.Equals("v2/project/" + apiKey + "/session/" + sessionId + "/stream")), It.IsAny<Dictionary<string, string>>(), It.IsAny<Dictionary<string, object>>()), Times.Once());
-        }
-
-        
+        }        
     }
 }
 

--- a/OpenTokTest/OpenTokTest.cs
+++ b/OpenTokTest/OpenTokTest.cs
@@ -537,6 +537,137 @@ namespace OpenTokSDKTest
         }
 
         [Fact]
+        public void ListArchivesTestWithValidSessionId()
+        {
+            var sessionId = "1_MX4xMjM0NTZ-flNhdCBNYXIgMTUgMTQ6NDI6MjMgUERUIDIwMTR-MC40OTAxMzAyNX4";
+            string returnString = "{\n" +
+                                " \"count\" : 6,\n" +
+                                " \"items\" : [ {\n" +
+                                " \"createdAt\" : 1395187930000,\n" +
+                                " \"duration\" : 22,\n" +
+                                " \"id\" : \"ef546c5a-4fd7-4e59-ab3d-f1cfb4148d1d\",\n" +
+                                " \"name\" : \"\",\n" +
+                                " \"partnerId\" : 123456,\n" +
+                                " \"reason\" : \"\",\n" +
+                                " \"sessionId\" : \"SESSIONID\",\n" +
+                                " \"size\" : 2909274,\n" +
+                                " \"status\" : \"available\",\n" +
+                                " \"url\" : \"http://tokbox.com.archive2.s3.amazonaws.com/123456%2Fef546c5" +
+                                "a-4fd7-4e59-ab3d-f1cfb4148d1d%2Farchive.mp4?Expires=1395188695&AWSAccessKeyId=AKIAI6" +
+                                "LQCPIXYVWCQV6Q&Signature=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\"\n" +
+                                " }, {\n" +
+                                " \"createdAt\" : 1395187910000,\n" +
+                                " \"duration\" : 14,\n" +
+                                " \"id\" : \"5350f06f-0166-402e-bc27-09ba54948512\",\n" +
+                                " \"name\" : \"\",\n" +
+                                " \"partnerId\" : 123456,\n" +
+                                " \"reason\" : \"\",\n" +
+                                " \"sessionId\" : \"SESSIONID\",\n" +
+                                " \"size\" : 1952651,\n" +
+                                " \"status\" : \"available\",\n" +
+                                " \"url\" : \"http://tokbox.com.archive2.s3.amazonaws.com/123456%2F5350f06" +
+                                "f-0166-402e-bc27-09ba54948512%2Farchive.mp4?Expires=1395188695&AWSAccessKeyId=AKIAI6" +
+                                "LQCPIXYVWCQV6Q&Signature=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\"\n" +
+                                " }, {\n" +
+                                " \"createdAt\" : 1395187836000,\n" +
+                                " \"duration\" : 62,\n" +
+                                " \"id\" : \"f6e7ee58-d6cf-4a59-896b-6d56b158ec71\",\n" +
+                                " \"name\" : \"\",\n" +
+                                " \"partnerId\" : 123456,\n" +
+                                " \"reason\" : \"\",\n" +
+                                " \"sessionId\" : \"SESSIONID\",\n" +
+                                " \"size\" : 8347554,\n" +
+                                " \"status\" : \"available\",\n" +
+                                " \"url\" : \"http://tokbox.com.archive2.s3.amazonaws.com/123456%2Ff6e7ee5" +
+                                "8-d6cf-4a59-896b-6d56b158ec71%2Farchive.mp4?Expires=1395188695&AWSAccessKeyId=AKIAI6" +
+                                "LQCPIXYVWCQV6Q&Signature=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\"\n" +
+                                " }, {\n" +
+                                " \"createdAt\" : 1395183243000,\n" +
+                                " \"duration\" : 544,\n" +
+                                " \"id\" : \"30b3ebf1-ba36-4f5b-8def-6f70d9986fe9\",\n" +
+                                " \"name\" : \"\",\n" +
+                                " \"partnerId\" : 123456,\n" +
+                                " \"reason\" : \"\",\n" +
+                                " \"sessionId\" : \"SESSIONID\",\n" +
+                                " \"size\" : 78499758,\n" +
+                                " \"status\" : \"available\",\n" +
+                                " \"url\" : \"http://tokbox.com.archive2.s3.amazonaws.com/123456%2F30b3ebf" +
+                                "1-ba36-4f5b-8def-6f70d9986fe9%2Farchive.mp4?Expires=1395188695&AWSAccessKeyId=AKIAI6" +
+                                "LQCPIXYVWCQV6Q&Signature=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\"\n" +
+                                " }, {\n" +
+                                " \"createdAt\" : 1394396753000,\n" +
+                                " \"duration\" : 24,\n" +
+                                " \"id\" : \"b8f64de1-e218-4091-9544-4cbf369fc238\",\n" +
+                                " \"name\" : \"showtime again\",\n" +
+                                " \"partnerId\" : 123456,\n" +
+                                " \"reason\" : \"\",\n" +
+                                " \"sessionId\" : \"SESSIONID\",\n" +
+                                " \"size\" : 2227849,\n" +
+                                " \"status\" : \"available\",\n" +
+                                " \"url\" : \"http://tokbox.com.archive2.s3.amazonaws.com/123456%2Fb8f64de" +
+                                "1-e218-4091-9544-4cbf369fc238%2Farchive.mp4?Expires=1395188695&AWSAccessKeyId=AKIAI6" +
+                                "LQCPIXYVWCQV6Q&Signature=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\"\n" +
+                                " }, {\n" +
+                                " \"createdAt\" : 1394321113000,\n" +
+                                " \"duration\" : 1294,\n" +
+                                " \"id\" : \"832641bf-5dbf-41a1-ad94-fea213e59a92\",\n" +
+                                " \"name\" : \"showtime\",\n" +
+                                " \"partnerId\" : 123456,\n" +
+                                " \"reason\" : \"\",\n" +
+                                " \"sessionId\" : \"SESSIONID\",\n" +
+                                " \"size\" : 42165242,\n" +
+                                " \"status\" : \"available\",\n" +
+                                " \"url\" : \"http://tokbox.com.archive2.s3.amazonaws.com/123456%2F832641b" +
+                                "f-5dbf-41a1-ad94-fea213e59a92%2Farchive.mp4?Expires=1395188695&AWSAccessKeyId=AKIAI6" +
+                                "LQCPIXYVWCQV6Q&Signature=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\"\n" +
+                                " } ]\n" +
+                                " }";
+            var mockClient = new Mock<HttpClient>();
+            mockClient.Setup(httpClient => httpClient.Get(It.IsAny<string>())).Returns(returnString);
+
+            OpenTok opentok = new OpenTok(apiKey, apiSecret);
+            opentok.Client = mockClient.Object;
+            ArchiveList archives = opentok.ListArchives(sessionId:sessionId);
+
+            Assert.NotNull(archives);
+            Assert.Equal(6, archives.Count);
+
+            mockClient.Verify(httpClient => httpClient.Get(It.Is<string>(url => url.Equals("v2/project/" + apiKey + $"/archive?offset=0&sessionId={sessionId}"))), Times.Once());
+        }
+
+        [Fact]
+        public void TestListArchivesBadCount()
+        {
+            OpenTok opentok = new OpenTok(apiKey, apiSecret);
+            try
+            {
+                opentok.ListArchives(count: -5);
+                Assert.True(false, "TestListArchivesBadCount should not have reached here as the count passed in was negative");
+            }
+            catch (OpenTokArgumentException ex)
+            {
+                Assert.Equal("count cannot be smaller than 0", ex.Message);
+            }            
+
+        }
+
+        [Fact]
+        public void TestListArchivesBadSessionId()
+        {
+            OpenTok opentok = new OpenTok(apiKey, apiSecret);
+            try
+            {
+                opentok.ListArchives(sessionId: "This-is-not-a-valid-session-id");
+                Assert.True(false, "TestListArchivesBadCount should not have reached here as the count passed in was negative");
+            }
+            catch (OpenTokArgumentException ex)
+            {
+                Assert.Equal("Session Id is not valid", ex.Message);
+            }
+
+        }
+
+        [Fact]
         public void StartArchiveTest()
         {
             string sessionId = "SESSIONID";
@@ -1358,6 +1489,8 @@ namespace OpenTokSDKTest
             
             mockClient.Verify(httpClient => httpClient.Put(It.Is<string>(url => url.Equals("v2/project/" + apiKey + "/session/" + sessionId + "/stream")), It.IsAny<Dictionary<string, string>>(), It.IsAny<Dictionary<string, object>>()), Times.Once());
         }
+
+        
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ paginate the Archives you receive using the offset and count parameters. This wi
 `OpenTokSDK.ArchiveList` object.
 
 ```csharp
-// Get a list with the first 1000 archives created by the API Key
+// Get a list with the first 50 archives created by the API Key
 var archives = OpenTok.ListArchives();
 
 // Get a list of the first 50 archives created by the API Key
@@ -169,6 +169,9 @@ var archives = OpenTok.ListArchives(0, 50);
 
 // Get a list of the next 50 archives
 var archives = OpenTok.ListArchives(50, 50);
+
+// Get a list of the first 50 archives created for the given sessionId
+var archives = OpenTok.ListArchives(sessionId:sessionId);
 ```
 
 Note that you can also create an automatically archived session, by passing in `ArchiveMode.ALWAYS`


### PR DESCRIPTION
Adding the ability to list archives by session per #73 - this will validate 

Removed empty override of `ListArchives` method, enabled default parameters for `ListArchive` to mimic the behavior (consequentially this is not a BC)

Fixed error message in ListArchive (it was saying count cannot be less than one while checking if it's less than 0)

Fixed error checking in GetPartnerIdFromSessionId, it would not check if 1 was in the array's range and kick up an index out of range exception for some malformed tokens, standardized it so it kicks up a FormatException.

Fixed description in the README of ListArchive method. Added example for Listing archives with SessionId