### PR TITLE
Automatic release on new GitHub release

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -18,6 +18,8 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: '3.1.401'
+    - name: Clean
+      run: dotnet clean OpenTok.sln --configuration Release && dotnet nuget locals all --clear
     - name: Install dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
         with:
           ref: ${{ github.event.release.target_commitish }}      
       - name: Release Nuget
-        uses: nexmo/github-actions/nuget-release@master
+        uses: nexmo/github-actions/nuget-release@main
         env:
           PROJECT_FILE : OpenTok/OpenTok.csproj          
           BRANCH: master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,3 +21,4 @@ jobs:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
           GITHUB_USER_NAME: NexmoDev
           GITHUB_EMAIL: 44278943+NexmoDev@users.noreply.github.com
+          OUTPUT_PATH: OpenTok/bin/Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+name: Nuget Release
+on:
+  release:
+    types: [published]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.release.target_commitish }}      
+      - name: Release Nuget
+        uses: nexmo/github-actions/nuget-release@master
+        env:
+          PROJECT_FILE : OpenTok/OpenTok.csproj          
+          BRANCH: master
+          ORGANIZATION: opentok
+          REPO: Opentok-.NET-SDK
+          TAG: ${{ github.event.release.tag_name }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+          GITHUB_USER_NAME: NexmoDev
+          GITHUB_EMAIL: 44278943+NexmoDev@users.noreply.github.com


### PR DESCRIPTION
This PR will automate releases to NuGet whenever a new release is cut in GitHub. 

When a new release happens in Github the action will do the following:

1. Pull down the repo
2. Update the csproj to reflect the new version
3. Commit the new version and push the update to master
4. Move the Release tag to the new commit
5. Push the changed tagged back up to github
6. Build the SDK
7. Push the SDK up to NuGet.