### PR TITLE
Adding ScreenShareType for archive/broadcast. adding SetArchiveLayout

### DIFF
--- a/OpenTok/ArchiveLayout.cs
+++ b/OpenTok/ArchiveLayout.cs
@@ -22,5 +22,17 @@ namespace OpenTokSDK
         [JsonProperty("stylesheet", DefaultValueHandling = DefaultValueHandling.Ignore, NullValueHandling = NullValueHandling.Ignore)]
         [DefaultValue("")]
         public string StyleSheet { get; set; }
+
+        /// <summary>
+        /// The <see cref="ScreenShareLayoutType"/>to use when there is a screen-sharing 
+        /// stream in the session. Note that to use this property, 
+        /// you must set the <see cref="Type"/> property to <see cref="LayoutType.bestFit"/> 
+        /// and leave the <see cref="StyleSheet"/> property unset. 
+        /// For more information, see Layout types for screen sharing.
+        /// NOTE: <see cref="LayoutType.custom"/> is not valid for this property
+        /// </summary>
+        [JsonConverter(typeof(StringEnumConverter), true)]
+        [JsonProperty("screenSharetype")]
+        public ScreenShareLayoutType? ScreenShareType { get; set; }
     }
 }

--- a/OpenTok/ArchiveLayout.cs
+++ b/OpenTok/ArchiveLayout.cs
@@ -32,7 +32,7 @@ namespace OpenTokSDK
         /// NOTE: <see cref="LayoutType.custom"/> is not valid for this property
         /// </summary>
         [JsonConverter(typeof(StringEnumConverter), true)]
-        [JsonProperty("screenSharetype")]
+        [JsonProperty("screenSharetype", NullValueHandling = NullValueHandling.Ignore)]
         public ScreenShareLayoutType? ScreenShareType { get; set; }
     }
 }

--- a/OpenTok/BroadcastLayout.cs
+++ b/OpenTok/BroadcastLayout.cs
@@ -83,7 +83,7 @@ namespace OpenTokSDK
         /// The Stylesheet for the Custom Layout
         /// </summary>
         [JsonProperty("stylesheet")]
-        public string Stylesheet { get; set; }
+        public string Stylesheet { get; set; } = null;
 
         /// <summary>
         /// The <see cref="LayoutType"/>to use when there is a screen-sharing 

--- a/OpenTok/BroadcastLayout.cs
+++ b/OpenTok/BroadcastLayout.cs
@@ -41,11 +41,31 @@ namespace OpenTokSDK
             Custom
         }
 
+        /// <summary>
+        /// Initalizes a Broadcast layout with the given <see cref="ScreenShareLayoutType"/>, automatically
+        /// sets the Type to bestFit
+        /// </summary>
+        /// <param name="type"></param>
+        public BroadcastLayout(ScreenShareLayoutType type)
+        {
+            Type = LayoutType.BestFit;
+            ScreenShareType = type;
+        }
+
+        /// <summary>
+        /// Initalizes a BroadcastLayout with the given <see cref="LayoutType"/>
+        /// </summary>
+        /// <param name="Type"></param>
         public BroadcastLayout(LayoutType Type)
         {
             this.Type = Type;
         }
 
+        /// <summary>
+        /// Initalizes a BroadcastLayout with the given <see cref="LayoutType"/> and stylesheet - note Type must be <see cref="LayoutType.Custom"/>
+        /// </summary>
+        /// <param name="Type"></param>
+        /// <param name="Stylesheet"></param>
         public BroadcastLayout(LayoutType Type, string Stylesheet)
         {
             this.Type = Type;
@@ -64,5 +84,17 @@ namespace OpenTokSDK
         /// </summary>
         [JsonProperty("stylesheet")]
         public string Stylesheet { get; set; }
+
+        /// <summary>
+        /// The <see cref="LayoutType"/>to use when there is a screen-sharing 
+        /// stream in the session. Note that to use this property, 
+        /// you must set the <see cref="Type"/> property to <see cref="LayoutType.BestFit"/> 
+        /// and leave the <see cref="Stylesheet"/> property unset. 
+        /// For more information, see Layout types for screen sharing.
+        /// NOTE: <see cref="LayoutType.Custom"/> is not valid for this property
+        /// </summary>
+        [JsonConverter(typeof(StringEnumConverter), true)]
+        [JsonProperty("screenSharetype")]
+        public ScreenShareLayoutType? ScreenShareType { get; set; }
     }
 }

--- a/OpenTok/BroadcastLayout.cs
+++ b/OpenTok/BroadcastLayout.cs
@@ -94,7 +94,7 @@ namespace OpenTokSDK
         /// NOTE: <see cref="LayoutType.Custom"/> is not valid for this property
         /// </summary>
         [JsonConverter(typeof(StringEnumConverter), true)]
-        [JsonProperty("screenSharetype")]
+        [JsonProperty("screenSharetype", NullValueHandling = NullValueHandling.Ignore)]
         public ScreenShareLayoutType? ScreenShareType { get; set; }
     }
 }

--- a/OpenTok/OpenTok.cs
+++ b/OpenTok/OpenTok.cs
@@ -300,6 +300,10 @@ namespace OpenTokSDK
                 {
                     throw new OpenTokArgumentException("Could not set layout, stylesheet must be set if and only if type is custom");
                 }
+                else if(layout.ScreenShareType != null && layout.Type != LayoutType.bestFit)
+                {
+                    throw new OpenTokArgumentException($"Could not set screenShareLayout, when screenShareType is set, layout.Type must be bestFit, was {layout.ScreenShareType}");
+                }
                 data.Add("layout", layout);
             }
 
@@ -534,6 +538,10 @@ namespace OpenTokSDK
                 {
                     throw new OpenTokArgumentException("Could not set the layout. Either an invalid JSON or an invalid layout options.");
                 }
+                else if (layout.ScreenShareType != null && layout.Type != BroadcastLayout.LayoutType.BestFit)
+                {
+                    throw new OpenTokArgumentException($"Could not set screenShareLayout, when screenShareType is set, layout.Type must be bestFit, was {layout.ScreenShareType}");
+                }
                 else
                 {
                     if (layout.Type.Equals(BroadcastLayout.LayoutType.Custom))
@@ -607,6 +615,10 @@ namespace OpenTokSDK
                     (!layout.Type.Equals(BroadcastLayout.LayoutType.Custom) && !String.IsNullOrEmpty(layout.Stylesheet)))
                 {
                     throw new OpenTokArgumentException("Could not set the layout. Either an invalid JSON or an invalid layout options.");
+                }
+                else if (layout.ScreenShareType != null && layout.Type != BroadcastLayout.LayoutType.BestFit)
+                {
+                    throw new OpenTokArgumentException($"Could not set screenShareLayout, when screenShareType is set, layout.Type must be bestFit, was {layout.ScreenShareType}");
                 }
                 else
                 {

--- a/OpenTok/OpenTok.cs
+++ b/OpenTok/OpenTok.cs
@@ -626,11 +626,58 @@ namespace OpenTokSDK
                     if (layout.Type.Equals(BroadcastLayout.LayoutType.Custom))
                     {
                         data.Add("stylesheet", layout.Stylesheet);
+                    }      
+                    if (layout.ScreenShareType != null)
+                    {
+                        data.Add("screenShareType", OpenTokUtils.convertToCamelCase(layout.ScreenShareType.ToString()));
                     }
                 }
             }
 
             Client.Put(url, headers, data);
+        }
+
+
+        /// <summary>
+        /// Allows you to Dynamically change the layout of a composed archive while it's being recorded
+        /// see <a href="https://tokbox.com/developer/guides/archiving/layout-control.html">Customizing the video layout for composed archives</a>
+        /// for details regarding customizing a layout.
+        /// </summary>
+        /// <param name="archiveId"></param>
+        /// <param name="layout"></param>
+        /// <returns></returns>
+        public bool SetArchiveLayout(string archiveId, ArchiveLayout layout)
+        {
+            string url = $"v2/project/{ApiKey}/archive/{archiveId}/layout";
+            var headers = new Dictionary<string, string> { { "Content-type", "application/json" } };
+            var data = new Dictionary<string, object>();
+            if(layout != null)
+            {
+                if (layout.Type == LayoutType.custom && string.IsNullOrEmpty(layout.StyleSheet))
+                {
+                    throw new OpenTokArgumentException("Invalid layout, layout is custom but no stylesheet provided");
+                }
+                else if(layout.Type != LayoutType.custom && !string.IsNullOrEmpty(layout.StyleSheet))
+                {
+                    throw new OpenTokArgumentException("Invalid layout, layout is not custom, but stylesheet is set");
+                }
+
+                data.Add("type", layout.Type.ToString());
+                if (!string.IsNullOrEmpty(layout.StyleSheet))
+                {
+                    data.Add("stylesheet", layout.StyleSheet);
+                }
+                if (layout.ScreenShareType != null)
+                {
+                    if(layout.Type != LayoutType.bestFit)
+                    {
+                        throw new OpenTokArgumentException("Invalid layout, when ScreenShareType is set, Type must be bestFit");
+                    }
+                    data.Add("screenshareType", OpenTokUtils.convertToCamelCase(layout.ScreenShareType.ToString()));
+                }
+            }
+            Client.Put(url, headers, data);
+            return true;
         }
 
         /// <summary>

--- a/OpenTok/OpenTok.cs
+++ b/OpenTok/OpenTok.cs
@@ -302,7 +302,7 @@ namespace OpenTokSDK
                 }
                 else if(layout.ScreenShareType != null && layout.Type != LayoutType.bestFit)
                 {
-                    throw new OpenTokArgumentException($"Could not set screenShareLayout, when screenShareType is set, layout.Type must be bestFit, was {layout.ScreenShareType}");
+                    throw new OpenTokArgumentException($"Could not set screenShareLayout. When screenShareType is set, layout.Type must be bestFit, was {layout.Type}");
                 }
                 data.Add("layout", layout);
             }
@@ -540,7 +540,7 @@ namespace OpenTokSDK
                 }
                 else if (layout.ScreenShareType != null && layout.Type != BroadcastLayout.LayoutType.BestFit)
                 {
-                    throw new OpenTokArgumentException($"Could not set screenShareLayout, when screenShareType is set, layout.Type must be bestFit, was {layout.ScreenShareType}");
+                    throw new OpenTokArgumentException($"Could not set screenShareLayout. When screenShareType is set, layout.Type must be bestFit, was {layout.Type}");
                 }
                 else
                 {
@@ -618,7 +618,7 @@ namespace OpenTokSDK
                 }
                 else if (layout.ScreenShareType != null && layout.Type != BroadcastLayout.LayoutType.BestFit)
                 {
-                    throw new OpenTokArgumentException($"Could not set screenShareLayout, when screenShareType is set, layout.Type must be bestFit, was {layout.ScreenShareType}");
+                    throw new OpenTokArgumentException($"Could not set screenShareLayout. When screenShareType is set, layout.Type must be bestFit, was {layout.Type}");
                 }
                 else
                 {

--- a/OpenTok/OpenTok.cs
+++ b/OpenTok/OpenTok.cs
@@ -550,7 +550,7 @@ namespace OpenTokSDK
                     }
                     else
                     {
-                        data.Add("layout", new { type = OpenTokUtils.convertToCamelCase(layout.Type.ToString()) });
+                        data.Add("layout", layout);
                     }
                 }
             }

--- a/OpenTok/ScreenShareLayoutType.cs
+++ b/OpenTok/ScreenShareLayoutType.cs
@@ -1,0 +1,27 @@
+﻿namespace OpenTokSDK
+{
+
+    /// <summary>
+    /// For archive and broadcast layouts, the layout type to use with screen shares
+    /// If this enum is being used, the Type property should be set to BestFit
+    /// </summary>
+    public enum ScreenShareLayoutType
+    {
+        /// <summary>
+        /// Picture-in-Picture
+        /// </summary>
+        Pip,
+        /// <summary>
+        /// /Best Fit
+        /// </summary>
+        BestFit,
+        /// <summary>
+        /// Vertical Presentation
+        /// </summary>
+        VerticalPresentation,
+        /// <summary>
+        /// Horizontal Presentation
+        /// </summary>
+        HorizontalPresentation        
+    }
+}

--- a/OpenTok/Util/HttpClient.cs
+++ b/OpenTok/Util/HttpClient.cs
@@ -208,7 +208,7 @@ namespace OpenTokSDK.Util
             {
                 if (headers["Content-type"] == "application/json")
                 {
-                    return JsonConvert.SerializeObject(data, Newtonsoft.Json.Formatting.None, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
+                    return JsonConvert.SerializeObject(data);
                 }
                 else if (headers["Content-type"] == "application/x-www-form-urlencoded")
                 {

--- a/OpenTok/Util/HttpClient.cs
+++ b/OpenTok/Util/HttpClient.cs
@@ -208,7 +208,7 @@ namespace OpenTokSDK.Util
             {
                 if (headers["Content-type"] == "application/json")
                 {
-                    return JsonConvert.SerializeObject(data);
+                    return JsonConvert.SerializeObject(data, Newtonsoft.Json.Formatting.None, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
                 }
                 else if (headers["Content-type"] == "application/x-www-form-urlencoded")
                 {

--- a/OpenTokTest/OpenTokTest.cs
+++ b/OpenTokTest/OpenTokTest.cs
@@ -811,7 +811,7 @@ namespace OpenTokSDKTest
             catch (OpenTokArgumentException ex)
             {
 
-                Assert.Equal($"Could not set screenShareLayout, when screenShareType is set, layout.Type must be bestFit, was BestFit", ex.Message);
+                Assert.Equal($"Could not set screenShareLayout. When screenShareType is set, layout.Type must be bestFit, was {layout.Type}", ex.Message);
             }            
         }        
 
@@ -1597,7 +1597,7 @@ namespace OpenTokSDKTest
             }
             catch (OpenTokArgumentException ex)
             {
-                Assert.Equal($"Could not set screenShareLayout, when screenShareType is set, layout.Type must be bestFit, was {layout.ScreenShareType}", ex.Message);
+                Assert.Equal($"Could not set screenShareLayout. When screenShareType is set, layout.Type must be bestFit, was {layout.Type}", ex.Message);
             }
         }
 
@@ -1614,7 +1614,7 @@ namespace OpenTokSDKTest
             catch (OpenTokArgumentException ex)
             {
 
-                Assert.Equal($"Could not set screenShareLayout, when screenShareType is set, layout.Type must be bestFit, was BestFit", ex.Message);
+                Assert.Equal($"Could not set screenShareLayout. When screenShareType is set, layout.Type must be bestFit, was {layout.Type}", ex.Message);
             }
         }
 

--- a/OpenTokTest/OpenTokTest.cs
+++ b/OpenTokTest/OpenTokTest.cs
@@ -1490,6 +1490,47 @@ namespace OpenTokSDKTest
         [Fact]
         public void TestStartBroadcastWithScreenShareType()
         {
+            string sessionId = "SESSIONID";
+            string returnString = "{\n" +
+                                  " \"id\" : \"30b3ebf1-ba36-4f5b-8def-6f70d9986fe9\",\n" +
+                                  " \"sessionId\" : \"SESSIONID\",\n" +
+                                  " \"projectId\" : 123456,\n" +
+                                  " \"createdAt\" : 1395183243556,\n" +
+                                  " \"updatedAt\" : 1395183243556,\n" +
+                                  " \"resolution\" : \"640x480\",\n" +
+                                  " \"status\" : \"started\",\n" +
+                                  " \"broadcastUrls\": { \n" +
+                                    " \"hls\": \"http://server/fakepath/playlist.m3u8\", \n" +
+                                  " } \n" +
+                                " }";
+            var mockClient = new Mock<HttpClient>();
+            var expectedUrl = $"v2/project/{apiKey}/broadcast";
+
+            var data = new Dictionary<string, object>() {
+                { "sessionId", sessionId },
+                { "maxDuration", 7200 },
+                { "outputs", new Dictionary<string, object>() {{"hls", new Object()}} }
+            };
+            var layout = new BroadcastLayout(ScreenShareLayoutType.BestFit);
+            data.Add("layout",layout);
+            mockClient.Setup(httpClient => httpClient.Post(
+                expectedUrl,
+                It.IsAny<Dictionary<string, string>>(),
+                It.Is< Dictionary<string, object>>(x=>                
+                    (string)x["sessionId"] == sessionId && x["layout"]==layout && (int)x["maxDuration"] == 7200
+                ))).Returns(returnString);
+
+            OpenTok opentok = new OpenTok(apiKey, apiSecret);
+            opentok.Client = mockClient.Object;
+            
+            Broadcast broadcast = opentok.StartBroadcast(sessionId, layout: layout);
+
+            Assert.NotNull(broadcast);
+            Assert.Equal(sessionId, broadcast.SessionId);
+            Assert.NotNull(broadcast.Id);
+            Assert.Equal(Broadcast.BroadcastStatus.STARTED, broadcast.Status);
+
+            mockClient.Verify(httpClient => httpClient.Post(It.Is<string>(url => url.Equals("v2/project/" + apiKey + "/broadcast")), It.IsAny<Dictionary<string, string>>(), It.IsAny<Dictionary<string, object>>()), Times.Once());
 
         }
 

--- a/OpenTokTest/OpenTokTest.cs
+++ b/OpenTokTest/OpenTokTest.cs
@@ -784,6 +784,37 @@ namespace OpenTokSDKTest
         }
 
         [Fact]
+        public void TestArchiveScreenShareLayout()
+        {
+            var expected = @"{""sessionId"":""abcd12345"",""name"":""an_archive_name"",""hasVideo"":true,""hasAudio"":true,""outputMode"":""composed"",""layout"":{""type"":""bestFit"",""screenSharetype"":""bestFit""}}";
+            var httpClient = new HttpClient();
+            var data = new Dictionary<string, object>() { { "sessionId", "abcd12345" }, { "name", "an_archive_name" }, { "hasVideo", true }, { "hasAudio", true }, { "outputMode", "composed" } };
+            var layout = new ArchiveLayout { Type = LayoutType.bestFit, ScreenShareType=ScreenShareLayoutType.BestFit };
+            data.Add("layout", layout);
+            var headers = new Dictionary<string, string>();
+            headers.Add("Content-type", "application/json");
+            var clientType = typeof(HttpClient);
+            var layoutString = (string)clientType.GetMethod("GetRequestPostData", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance).Invoke(httpClient, new object[] { data, headers });
+            Assert.Equal(expected, layoutString);
+        }
+
+        [Fact]
+        public void TestArchiveScreenShareInvalidType()
+        {
+            OpenTok opentok = new OpenTok(apiKey, apiSecret);
+            ArchiveLayout layout = new ArchiveLayout { Type = LayoutType.pip, ScreenShareType = ScreenShareLayoutType.BestFit };
+            try
+            {
+                opentok.StartArchive("abcd", layout: layout);
+            }
+            catch (OpenTokArgumentException ex)
+            {
+
+                Assert.Equal($"Could not set screenShareLayout, when screenShareType is set, layout.Type must be bestFit, was BestFit", ex.Message);
+            }            
+        }        
+
+        [Fact]
         public void TestArchiveCustomLayout()
         {
             var expected = @"{""sessionId"":""abcd12345"",""name"":""an_archive_name"",""hasVideo"":true,""hasAudio"":true,""outputMode"":""composed"",""layout"":{""type"":""custom"",""stylesheet"":""stream.instructor {position: absolute; width: 100%;  height:50%;}""}}";
@@ -1454,6 +1485,28 @@ namespace OpenTokSDKTest
             Assert.Equal(Broadcast.BroadcastStatus.STARTED, broadcast.Status);
 
             mockClient.Verify(httpClient => httpClient.Post(It.Is<string>(url => url.Equals("v2/project/" + apiKey + "/broadcast")), It.IsAny<Dictionary<string, string>>(), It.IsAny<Dictionary<string, object>>()), Times.Once());
+        }
+
+        [Fact]
+        public void TestStartBroadcastWithScreenShareType()
+        {
+
+        }
+
+        [Fact]
+        public void TestStartBroadcastScreenShareInvalidType()
+        {
+            OpenTok opentok = new OpenTok(apiKey, apiSecret);
+            BroadcastLayout layout = new BroadcastLayout(BroadcastLayout.LayoutType.Pip) { ScreenShareType = ScreenShareLayoutType.BestFit };
+            try
+            {
+                opentok.StartBroadcast("abcd", layout: layout);
+            }
+            catch (OpenTokArgumentException ex)
+            {
+
+                Assert.Equal($"Could not set screenShareLayout, when screenShareType is set, layout.Type must be bestFit, was BestFit", ex.Message);
+            }
         }
 
         [Fact]


### PR DESCRIPTION
Adding a method to set the layout for the archive, this is a parallel capability to what already exists for broadcasts so the functionality is mirrored.

Adding ScreenShareType to both Archive Layout and Broadcast layout so that folks can add them. Adding pre-flight validation for both, which is the precedent set for the OpenTok SDK, 