### PR TITLE
Devx 6491 - Update.NET Server SDK for Multiple Archives and Records

### DIFF
--- a/OpenTok/Archive.cs
+++ b/OpenTok/Archive.cs
@@ -109,6 +109,7 @@ namespace OpenTokSDK
             OutputMode = archive.OutputMode;
             Resolution = archive.Resolution;
             StreamMode = archive.StreamMode;
+            MultiArchiveTag = archive.MultiArchiveTag;
         }
 
         /// <summary>
@@ -200,6 +201,11 @@ namespace OpenTokSDK
         /// Whether streams included in the archive are selected automatically ("auto", the default) or manually.
         /// </summary>
         public StreamMode StreamMode { get; set; }
+
+        /// <summary>
+        /// The tag of the archive.
+        /// </summary>
+        public string MultiArchiveTag { get; set; }
 
         /// <summary>
         /// Stops the OpenTok archive if it is being recorded.

--- a/OpenTok/Broadcast.cs
+++ b/OpenTok/Broadcast.cs
@@ -91,6 +91,7 @@ namespace OpenTokSDK
             BroadcastUrls = broadcast.BroadcastUrls;
             StreamMode = broadcast.StreamMode;
             Settings = broadcast.Settings;
+            MultiBroadcastTag = broadcast.MultiBroadcastTag;
 
             if (BroadcastUrls == null)
                 return;
@@ -193,6 +194,9 @@ namespace OpenTokSDK
         /// </summary>
         [JsonProperty("settings")]
         public BroadcastSettings Settings { get; set; }
+        
+        [JsonProperty("multiBroadcastTag")]
+        public string MultiBroadcastTag { get; set; }
 
         /// <summary>
         /// Stops the live broadcasting if it is started.

--- a/OpenTok/OpenTok.cs
+++ b/OpenTok/OpenTok.cs
@@ -397,7 +397,7 @@ namespace OpenTokSDK
         /// <returns>
         /// The Archive object. This object includes properties defining the archive, including the archive ID.
         /// </returns>
-        public Archive StartArchive(string sessionId, string name = "", bool hasVideo = true, bool hasAudio = true, OutputMode outputMode = OutputMode.COMPOSED, string resolution = null, ArchiveLayout layout = null, StreamMode? streamMode = null)
+        public Archive StartArchive(string sessionId, string name = "", bool hasVideo = true, bool hasAudio = true, OutputMode outputMode = OutputMode.COMPOSED, string resolution = null, ArchiveLayout layout = null, StreamMode? streamMode = null, string multiArchiveTag = null)
         {
             if (string.IsNullOrEmpty(sessionId))
             {
@@ -430,6 +430,11 @@ namespace OpenTokSDK
                     throw new OpenTokArgumentException($"Could not set screenShareLayout. When screenShareType is set, layout.Type must be bestFit, was {layout.Type}");
                 }
                 data.Add("layout", layout);
+            }
+
+            if (multiArchiveTag is object)
+            {
+                data.Add("multiArchiveTag", multiArchiveTag);
             }
 
             if (streamMode.HasValue)
@@ -499,7 +504,7 @@ namespace OpenTokSDK
         /// <returns>
         /// The Archive object. This object includes properties defining the archive, including the archive ID.
         /// </returns>
-        public async Task<Archive> StartArchiveAsync(string sessionId, string name = "", bool hasVideo = true, bool hasAudio = true, OutputMode outputMode = OutputMode.COMPOSED, string resolution = null, ArchiveLayout layout = null, StreamMode? streamMode = null)
+        public async Task<Archive> StartArchiveAsync(string sessionId, string name = "", bool hasVideo = true, bool hasAudio = true, OutputMode outputMode = OutputMode.COMPOSED, string resolution = null, ArchiveLayout layout = null, StreamMode? streamMode = null, string multiArchiveTag = null)
         {
             if (string.IsNullOrEmpty(sessionId))
             {
@@ -539,6 +544,11 @@ namespace OpenTokSDK
                     throw new OpenTokArgumentException($"Could not set screenShareLayout. When screenShareType is set, layout.Type must be bestFit, was {layout.Type}");
                 }
                 data.Add("layout", layout);
+            }
+            
+            if (multiArchiveTag is object)
+            {
+                data.Add("multiArchiveTag", multiArchiveTag);
             }
 
             if (streamMode.HasValue)

--- a/OpenTok/OpenTok.cs
+++ b/OpenTok/OpenTok.cs
@@ -394,6 +394,7 @@ namespace OpenTokSDK
         /// <see cref="OpenTok.AddStreamToArchiveAsync"/> and
         /// <see cref="OpenTok.RemoveStreamFromArchiveAsync"/> methods).
         /// </param>
+        /// <param name="multiArchiveTag">The tag of the archive, with which to start, this is unique for each archive within session</param>
         /// <returns>
         /// The Archive object. This object includes properties defining the archive, including the archive ID.
         /// </returns>
@@ -501,6 +502,7 @@ namespace OpenTokSDK
         /// <see cref="OpenTok.AddStreamToArchiveAsync"/> and
         /// <see cref="OpenTok.RemoveStreamFromArchiveAsync"/> methods).
         /// </param>
+        /// <param name="multiArchiveTag">The tag of the archive, with which to start, this is unique for each archive within session</param>
         /// <returns>
         /// The Archive object. This object includes properties defining the archive, including the archive ID.
         /// </returns>
@@ -1023,6 +1025,7 @@ namespace OpenTokSDK
         /// the HLS URL will include a ?DVR query string appended to the end. See <a href="https://tokbox.com/developer/guides/broadcast/live-streaming/#dvr">DVR functionality</a></param>
         /// <param name="lowLatency">Whether to enable low-latency mode for the HLSstream. Some HLS players do not support low-latency mode. 
         /// This feature is incompatible with DVR mode HLS broadcasts. See <a href="https://tokbox.com/developer/guides/broadcast/live-streaming/#low-latency-hls-broadcasts">Low-latency HLS broadcasts</a></param>
+        /// <param name="multiBroadcastTag">The tag of the Broadcast, with which to start, this is unique for each Broadcast within session</param>
         /// <returns>The Broadcast object. This object includes properties defining the archive, including the archive ID.</returns>
         public Broadcast StartBroadcast(string sessionId, bool hls = true, List<Rtmp> rtmpList = null, string resolution = null,
             int maxDuration = 7200, BroadcastLayout layout = null, StreamMode? streamMode = null, bool dvr = false, bool? lowLatency = null, string multiBroadcastTag = null)

--- a/OpenTok/OpenTok.cs
+++ b/OpenTok/OpenTok.cs
@@ -1025,7 +1025,7 @@ namespace OpenTokSDK
         /// This feature is incompatible with DVR mode HLS broadcasts. See <a href="https://tokbox.com/developer/guides/broadcast/live-streaming/#low-latency-hls-broadcasts">Low-latency HLS broadcasts</a></param>
         /// <returns>The Broadcast object. This object includes properties defining the archive, including the archive ID.</returns>
         public Broadcast StartBroadcast(string sessionId, bool hls = true, List<Rtmp> rtmpList = null, string resolution = null,
-            int maxDuration = 7200, BroadcastLayout layout = null, StreamMode? streamMode = null, bool dvr = false, bool? lowLatency = null)
+            int maxDuration = 7200, BroadcastLayout layout = null, StreamMode? streamMode = null, bool dvr = false, bool? lowLatency = null, string multiBroadcastTag = null)
         {
             if (string.IsNullOrEmpty(sessionId))
             {
@@ -1097,6 +1097,11 @@ namespace OpenTokSDK
                 {
                     data.Add("layout", layout);
                 }
+            }
+            
+            if (multiBroadcastTag is object)
+            {
+                data.Add("multiBroadcastTag", multiBroadcastTag);
             }
 
             if (streamMode.HasValue)

--- a/OpenTokTest/ArchiveTests.cs
+++ b/OpenTokTest/ArchiveTests.cs
@@ -743,7 +743,7 @@ namespace OpenTokSDKTest
             OpenTok opentok = this.BuildOpenTok(mockClient.Object);
             Archive archive = opentok.StartArchive(SessionId, multiArchiveTag: multiArchiveTag);
             Assert.NotNull(archive);
-            Assert.Equal(SessionId, archive.SessionId);
+            Assert.Equal(multiArchiveTag, archive.MultiArchiveTag);
             Assert.NotEqual(Guid.Empty, archive.Id);
             mockClient.Verify(
                 httpClient => httpClient.Post(
@@ -767,7 +767,7 @@ namespace OpenTokSDKTest
             OpenTok opentok = this.BuildOpenTok(mockClient.Object);
             Archive archive = await opentok.StartArchiveAsync(SessionId, multiArchiveTag: multiArchiveTag);
             Assert.NotNull(archive);
-            Assert.Equal(SessionId, archive.SessionId);
+            Assert.Equal(multiArchiveTag, archive.MultiArchiveTag);
             Assert.NotEqual(Guid.Empty, archive.Id);
             mockClient.Verify(
                 httpClient => httpClient.PostAsync(

--- a/OpenTokTest/ArchiveTests.cs
+++ b/OpenTokTest/ArchiveTests.cs
@@ -730,6 +730,53 @@ namespace OpenTokSDKTest
                     It.IsAny<Dictionary<string, object>>()), Times.Once());
         }
 
+        [Fact]
+        public void StartArchiveWithMultiArchiveTag()
+        {
+            string responseJson = GetResponseJson();
+            string multiArchiveTagName = "multiArchiveTag";
+            string multiArchiveTag = "TestArchiveTag";
+            var mockClient = new Mock<HttpClient>();
+            mockClient.Setup(httpClient => httpClient.Post(It.IsAny<string>(), It.IsAny<Dictionary<string, string>>(),
+                    It.IsAny<Dictionary<string, object>>()))
+                .Returns(responseJson);
+            OpenTok opentok = this.BuildOpenTok(mockClient.Object);
+            Archive archive = opentok.StartArchive(SessionId, multiArchiveTag: multiArchiveTag);
+            Assert.NotNull(archive);
+            Assert.Equal(SessionId, archive.SessionId);
+            Assert.NotEqual(Guid.Empty, archive.Id);
+            mockClient.Verify(
+                httpClient => httpClient.Post(
+                    It.Is<string>(url => url.Equals("v2/project/" + ApiKey + "/archive")),
+                    It.IsAny<Dictionary<string, string>>(), 
+                    It.Is<Dictionary<string, object>>(dictionary => 
+                        dictionary.ContainsKey(multiArchiveTagName) && dictionary[multiArchiveTagName].ToString() == multiArchiveTag)), 
+                Times.Once());
+        }
+        
+        [Fact]
+        public async Task StartArchiveWithMultiArchiveTagAsync()
+        {
+            string responseJson = GetResponseJson();
+            string multiArchiveTagName = "multiArchiveTag";
+            string multiArchiveTag = "TestArchiveTag";
+            var mockClient = new Mock<HttpClient>();
+            mockClient.Setup(httpClient => httpClient.PostAsync(It.IsAny<string>(),
+                    It.IsAny<Dictionary<string, string>>(), It.IsAny<Dictionary<string, object>>()))
+                .ReturnsAsync(responseJson);
+            OpenTok opentok = this.BuildOpenTok(mockClient.Object);
+            Archive archive = await opentok.StartArchiveAsync(SessionId, multiArchiveTag: multiArchiveTag);
+            Assert.NotNull(archive);
+            Assert.Equal(SessionId, archive.SessionId);
+            Assert.NotEqual(Guid.Empty, archive.Id);
+            mockClient.Verify(
+                httpClient => httpClient.PostAsync(
+                    It.Is<string>(url => url.Equals("v2/project/" + ApiKey + "/archive")),
+                    It.IsAny<Dictionary<string, string>>(), 
+                    It.Is<Dictionary<string, object>>(dictionary => 
+                        dictionary.ContainsKey(multiArchiveTagName) && dictionary[multiArchiveTagName].ToString() == multiArchiveTag)), 
+                Times.Once());
+        }
 
         // AddStreamToArchive
 
@@ -1670,5 +1717,11 @@ namespace OpenTokSDKTest
 
             Assert.Equal("Session Id is not valid", exception.Message);
         }
+        
+        private OpenTok BuildOpenTok(HttpClient client) =>
+            new OpenTok(this.ApiKey, this.ApiSecret)
+            {
+                Client = client,
+            };
     }
 }

--- a/OpenTokTest/BroadcastTests.cs
+++ b/OpenTokTest/BroadcastTests.cs
@@ -412,6 +412,30 @@ namespace OpenTokSDKTest
             Assert.True(hls["lowLatency"]);
             Assert.False(hls["dvr"]);
         }
+        
+        [Fact]
+        public void StartBroadcastWithMultiBroadcastTag()
+        {
+            string multiBroadcastTagName = "multiBroadcastTag";
+            string multiBroadcastTag = "TestBroadcastTag";
+            string sessionId = "SESSIONID";
+            string returnString = GetResponseJson();
+            var mockClient = new Mock<HttpClient>();
+            mockClient.Setup(httpClient => httpClient.Post(It.IsAny<string>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<Dictionary<string, object>>())).Returns(returnString);
+            OpenTok opentok = new OpenTok(ApiKey, ApiSecret);
+            opentok.Client = mockClient.Object;
+            Broadcast broadcast = opentok.StartBroadcast(sessionId, multiBroadcastTag: multiBroadcastTag);
+            Assert.NotNull(broadcast);
+            Assert.Equal(multiBroadcastTag, broadcast.MultiBroadcastTag);
+            Assert.NotNull(broadcast.Id);
+            Assert.Equal(Broadcast.BroadcastStatus.STARTED, broadcast.Status);
+            mockClient.Verify(httpClient => httpClient.Post(
+                It.Is<string>(url => url.Equals("v2/project/" + ApiKey + "/broadcast")), 
+                It.IsAny<Dictionary<string, string>>(), 
+                It.Is<Dictionary<string, object>>(dictionary => 
+                    dictionary.ContainsKey(multiBroadcastTagName) && dictionary[multiBroadcastTagName].ToString() == multiBroadcastTag)), 
+                Times.Once());
+        }
 
         // AddStreamToBroadcast
 

--- a/OpenTokTest/Data/ArchiveTests/StartArchiveWithMultiArchiveTag-response.json
+++ b/OpenTokTest/Data/ArchiveTests/StartArchiveWithMultiArchiveTag-response.json
@@ -1,0 +1,13 @@
+{
+  "createdAt": 1395183243556,
+  "duration": 0,
+  "id": "30b3ebf1-ba36-4f5b-8def-6f70d9986fe9",
+  "name": "",
+  "partnerId": 123456,
+  "reason": "",
+  "sessionId": "1_MX4xMjM0NTZ-flNhdCBNYXIgMTUgMTQ6NDI6MjMgUERUIDIwMTR-MC40OTAxMzAyNX4",
+  "size": 0,
+  "status": "started",
+  "url": null,
+  "multiArchiveTag": "TestArchiveTag"
+}

--- a/OpenTokTest/Data/ArchiveTests/StartArchiveWithMultiArchiveTagAsync-response.json
+++ b/OpenTokTest/Data/ArchiveTests/StartArchiveWithMultiArchiveTagAsync-response.json
@@ -1,0 +1,13 @@
+{
+  "createdAt": 1395183243556,
+  "duration": 0,
+  "id": "30b3ebf1-ba36-4f5b-8def-6f70d9986fe9",
+  "name": "",
+  "partnerId": 123456,
+  "reason": "",
+  "sessionId": "1_MX4xMjM0NTZ-flNhdCBNYXIgMTUgMTQ6NDI6MjMgUERUIDIwMTR-MC40OTAxMzAyNX4",
+  "size": 0,
+  "status": "started",
+  "url": null,
+  "multiArchiveTag": "TestArchiveTag"
+}

--- a/OpenTokTest/Data/BroadcastTests/StartBroadcastWithMultiBroadcastTag-response.json
+++ b/OpenTokTest/Data/BroadcastTests/StartBroadcastWithMultiBroadcastTag-response.json
@@ -1,0 +1,14 @@
+{
+  "id": "30b3ebf1-ba36-4f5b-8def-6f70d9986fe9",
+  "sessionId": "SESSIONID",
+  "projectId": 123456,
+  "createdAt": 1395183243556,
+  "updatedAt": 1395183243556,
+  "resolution": "640x480",
+  "status": "started",
+  "broadcastUrls": {
+    "hls": "http://server/fakepath/playlist.m3u8"
+  },
+  "settings": { "hls": { "lowLatency": false } },
+  "multiBroadcastTag": "TestBroadcastTag"
+}

--- a/OpenTokTest/OpenTokTest.csproj
+++ b/OpenTokTest/OpenTokTest.csproj
@@ -77,6 +77,12 @@
     <Content Include="Data\ArchiveTests\ListArchives-response.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Data\ArchiveTests\StartArchiveWithMultiArchiveTag-response.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Data\ArchiveTests\StartArchiveWithMultiArchiveTagAsync-response.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="Data\ArchiveTests\StopArchiveAsyncFromArchiveObject-response.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/OpenTokTest/OpenTokTest.csproj
+++ b/OpenTokTest/OpenTokTest.csproj
@@ -242,6 +242,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Moq" Version="4.14.1" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4"/>
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>

--- a/OpenTokTest/OpenTokTest.csproj
+++ b/OpenTokTest/OpenTokTest.csproj
@@ -197,6 +197,9 @@
     <Content Include="Data\BroadcastTests\GetBroadcast-response.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Data\BroadcastTests\StartBroadcastWithMultiBroadcastTag-response.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="Data\BroadcastTests\StopBroadcastAsync-response.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>


### PR DESCRIPTION
Handle "multiTag" for both Archive and Broadcast.

Note: The following PR (https://github.com/opentok/Opentok-.NET-SDK/pull/191) implements BroadcastAsync, so we'll have to include "MultiBroadcastTag" later on.