### PR TITLE
Devx 5915 - Update .NET Server SDK for 1080p Archive/Broadcast

### DIFF
--- a/OpenTok/Broadcast.cs
+++ b/OpenTok/Broadcast.cs
@@ -148,7 +148,7 @@ namespace OpenTokSDK
         public long UpdatedAt { get; set; }
 
         /// <summary>
-        /// The resolution of the broadcast: either "640x480" (SD, the default) or "1280x720" (HD).
+        /// The resolution of the broadcast: either "640x480" (SD landscape, the default), "1280x720" (HD landscape), "1920x1080" (FHD landscape), "480x640" (SD portrait), "720x1280" (HD portrait), or "1080x1920" (FHD portrait).
         /// </summary>
         [JsonProperty("resolution")]
         public string Resolution { get; set; }

--- a/OpenTokTest/OpenTokTest.csproj
+++ b/OpenTokTest/OpenTokTest.csproj
@@ -233,6 +233,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Moq" Version="4.14.1" />
+    <PackageReference Include="System.Net.Http" Version="4.3.2"/>
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>

--- a/OpenTokTest/OpenTokTest.csproj
+++ b/OpenTokTest/OpenTokTest.csproj
@@ -233,7 +233,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Moq" Version="4.14.1" />
-    <PackageReference Include="System.Net.Http" Version="4.3.2"/>
+    <PackageReference Include="System.Net.Http" Version="4.3.4"/>
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>

--- a/README.md
+++ b/README.md
@@ -137,8 +137,9 @@ the `OpenTok.StartArchive()` method.
 You can also disable audio or video recording by setting the `hasAudio` or `hasVideo` parameter of
 the `OpenTok.StartArchive()` method `false`.
 
-You can also set the resolution of the recording to high definition by setting the `resolution` parameter of
-the `OpenTok.StartArchive()` method to `"1280x720"`. Please note that you cannot specify the `resolution` when you set the `outputMode` parameter to `OutputMode.INDIVIDUAL`.
+You can also set the resolution of the recording to high definition by setting the `resolution` parameter of the `OpenTok.StartArchive()` method.
+Accepted values are "640x480" (SD landscape, the default), "1280x720" (HD landscape), "1920x1080" (FHD landscape), "480x640" (SD portrait), "720x1280" (HD portrait), or "1080x1920" (FHD portrait). 
+Please note that you cannot specify the `resolution` when you set the `outputMode` parameter to `OutputMode.INDIVIDUAL`.
 
 By default, all streams are recorded to a single (composed) file. You can record the different
 streams in the session to individual files (instead of a single composed file) by setting the

--- a/Samples/Broadcasting/views/Host.cshtml
+++ b/Samples/Broadcasting/views/Host.cshtml
@@ -31,7 +31,19 @@
                                     <input type="radio" name="resolution" value="640x480"> 640x480
                                 </label>
                                 <label class="help-block">
-                                    <input type="radio" name="resolution" value="1280x720" checked> 1280x720
+                                    <input type="radio" name="resolution" value="1280x720"> 1280x720
+                                </label>
+                                <label class="help-block">
+                                    <input type="radio" name="resolution" value="1920x1080" checked> 1920x1080
+                                </label>
+                                <label class="help-block">
+                                    <input type="radio" name="resolution" value="480x640"> 480x640
+                                </label>
+                                <label class="help-block">
+                                    <input type="radio" name="resolution" value="720x1280"> 720x1280
+                                </label>
+                                <label class="help-block">
+                                    <input type="radio" name="resolution" value="1080x1920"> 1080x1920
                                 </label>
                             </p>
                         </div>


### PR DESCRIPTION
Add all available resolutions on Readme, XML doc and Sample apps.
Resolutions were already handled in OpenTok.

New PR to target the dev branch. Previous one can be found [here](https://github.com/opentok/Opentok-.NET-SDK/pull/197)