### PR TITLE
[DEVX-6967] Custom user-agent

### DIFF
--- a/OpenTok/OpenTok.cs
+++ b/OpenTok/OpenTok.cs
@@ -34,6 +34,12 @@ namespace OpenTokSDK
         /// </summary>
         public HttpClient Client { internal get; set; }
 
+        /// <summary>
+        /// Sets a custom user-agent value. The HttpClient will append this value, if it exists, to the initial user-agent value.
+        /// </summary>
+        /// <param name="value">The custom user-agent value.</param>
+        public void SetCustomUserAgent(string value) => this.Client.CustomUserAgent = value;
+
         private bool _debug;
 
         private IEnumerable<string> _validResolutions = new[]

--- a/OpenTok/Util/HttpClient.cs
+++ b/OpenTok/Util/HttpClient.cs
@@ -30,6 +30,11 @@ namespace OpenTokSDK.Util
             1970, 1, 1, 0, 0, 0, DateTimeKind.Utc
         );
 
+        /// <summary>
+        /// The custom user-agent value. The HttpClient will append this value, if it exists, to the initial user-agent value.
+        /// </summary>
+        public string CustomUserAgent { get; internal set; }
+
         internal HttpClient()
         {
         }
@@ -300,7 +305,9 @@ namespace OpenTokSDK.Util
             }
 
             request.ContentLength = data.Length;
-            request.UserAgent = OpenTokVersion.GetVersion();
+            request.UserAgent = this.CustomUserAgent != null 
+                ? $"{OpenTokVersion.GetVersion()}/{this.CustomUserAgent}"
+                : OpenTokVersion.GetVersion();
             if (headers.ContainsKey("Content-Type"))
             {
                 request.ContentType = headers["Content-Type"];

--- a/OpenTokTest/OpenTokTest.csproj
+++ b/OpenTokTest/OpenTokTest.csproj
@@ -289,7 +289,7 @@
     <PackageReference Include="AutoFixture" Version="4.17.0" />
     <PackageReference Include="Enums.NET" Version="4.0.0" />
     <PackageReference Include="Moq" Version="4.14.1" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4"/>
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>

--- a/OpenTokTest/OpenTokTests.cs
+++ b/OpenTokTest/OpenTokTests.cs
@@ -1,0 +1,19 @@
+using AutoFixture;
+using OpenTokSDK;
+using Xunit;
+
+namespace OpenTokSDKTest
+{
+    public class OpenTokTests
+    {
+        [Fact]
+        public void SetCustomUserAgent_ShouldSetUserAgentOnClient()
+        {
+            var fixture = new Fixture();
+            var customUserAgent = fixture.Create<string>();
+            var sut = new OpenTok(fixture.Create<int>(), fixture.Create<string>());
+            sut.SetCustomUserAgent(customUserAgent);
+            Assert.Equal(customUserAgent, sut.Client.CustomUserAgent);
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -52,6 +52,17 @@ string ApiSecret = "YOUR API SECRET";
 var OpenTok = new OpenTok(ApiKey, ApiSecret);
 ```
 
+#### Overriding the request's user-agent value
+
+You can decide to add a custom value to the user-agent value passed with every request.
+
+```csharp
+var OpenTok = new OpenTok(ApiKey, ApiSecret);
+OpenTok.SetCustomUserAgent(customUserAgent);
+```
+
+If the custom value has been set, the user-agent will comply to the following format: `Opentok-DotNet-SDK/{version}/{customValue}`.
+
 ### Creating Sessions
 
 To create an OpenTok Session, call the `OpenTok` instance's


### PR DESCRIPTION
A custom user-agent can be set on OpenTok's client. If the value is set, the HttpClient will append it to the default one.
This is a minimal implementation, meaning without impacting all HttpClient's methods. 
The step has been documented in the Readme.