### PR TITLE
Modify claim name "data" to "connection_data"

### DIFF
--- a/OpenTok/Util/TokenGenerator.cs
+++ b/OpenTok/Util/TokenGenerator.cs
@@ -97,7 +97,7 @@ namespace OpenTokSDK.Util
                 { "jti", GenerateTokenId() },
                 { "initial_layout_list", string.Join(" ", InitialLayoutClasses) },
                 { "nonce", OpenTokUtils.GetRandomNumber() },
-                { "data", this.Data },
+                { "connection_data", this.Data },
             };
 
             return payload;

--- a/OpenTokTest/TokenTests.cs
+++ b/OpenTokTest/TokenTests.cs
@@ -155,7 +155,7 @@ namespace OpenTokSDKTest
         public void GenerateToken_ShouldSetData()
         {
             var token = sut.GenerateToken(SessionId, data: "Some data.");
-            ExtractClaims(token)["data"].Should().Be("Some data.");
+            ExtractClaims(token)["connection_data"].Should().Be("Some data.");
         }
 
         [Fact]


### PR DESCRIPTION
Similar to: https://github.com/Vonage/vonage-python-sdk/pull/304

There was a slight discrepancy in specifying connection data. The accurate claim should be connection_data => 'name=Johnny', rather than 'data' => 'name=Johnny'