### PR TITLE
Removed "Expect" header

### DIFF
--- a/OpenTok/Util/HttpClient.cs
+++ b/OpenTok/Util/HttpClient.cs
@@ -320,7 +320,6 @@ namespace OpenTokSDK.Util
             if (headers.ContainsKey("Content-Type"))
             {
                 request.ContentType = headers["Content-Type"];
-                request.Expect = headers["Content-Type"];
                 headers.Remove("Content-Type");
             }
 


### PR DESCRIPTION
Expect header should not contain values that are generally passed to Content-type.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Expect

Fixes #269.
